### PR TITLE
accurately compute same-padding for model

### DIFF
--- a/model.py
+++ b/model.py
@@ -115,11 +115,11 @@ class Encoder(nn.Module):
 class Decoder(nn.Module):
     def __init__(self, hid_dim, resolution):
         super().__init__()
-        self.conv1 = nn.ConvTranspose2d(hid_dim, hid_dim, 5, stride=(2, 2), padding=3)
-        self.conv2 = nn.ConvTranspose2d(hid_dim, hid_dim, 5, stride=(2, 2), padding=2)
-        self.conv3 = nn.ConvTranspose2d(hid_dim, hid_dim, 5, stride=(2, 2), padding=2)
-        self.conv4 = nn.ConvTranspose2d(hid_dim, hid_dim, 5, stride=(2, 2), padding=3)
-        self.conv5 = nn.ConvTranspose2d(hid_dim, hid_dim, 5, stride=(1, 1), padding=1)
+        self.conv1 = nn.ConvTranspose2d(hid_dim, hid_dim, 5, stride=(2, 2), padding=2, output_padding=1).to(device)
+        self.conv2 = nn.ConvTranspose2d(hid_dim, hid_dim, 5, stride=(2, 2), padding=2, output_padding=1).to(device)
+        self.conv3 = nn.ConvTranspose2d(hid_dim, hid_dim, 5, stride=(2, 2), padding=2, output_padding=1).to(device)
+        self.conv4 = nn.ConvTranspose2d(hid_dim, hid_dim, 5, stride=(2, 2), padding=2, output_padding=1).to(device)
+        self.conv5 = nn.ConvTranspose2d(hid_dim, hid_dim, 5, stride=(1, 1), padding=2).to(device)
         self.conv6 = nn.ConvTranspose2d(hid_dim, 4, 3, stride=(1, 1), padding=1)
         self.decoder_initial_size = (8, 8)
         self.decoder_pos = SoftPositionEmbed(hid_dim, self.decoder_initial_size)
@@ -132,7 +132,7 @@ class Decoder(nn.Module):
         x = F.relu(x)
         x = self.conv2(x)
         x = F.relu(x)
-        x = F.pad(x, (4,4,4,4))
+#         x = F.pad(x, (4,4,4,4)) # no longer needed
         x = self.conv3(x)
         x = F.relu(x)
         x = self.conv4(x)


### PR DESCRIPTION
Explanation: Tensorflow’s 'SAME' padding option/flag will automatically calculate what same padding would be and infer 'output_padding' (if it is left as default/None) so that input shape = output shape (assuming stride of 0). However, Pytorch does not infer the value of output_padding and instead treats its default value explicitly as 0. In this case, if output_padding is left as 0, input shape != output shape. Adding 'output_padding=1' flag here retains the shape of the input. This change prevents the existence of "borders" of solid color around the final generated output image. Size of final generated output image with these changes is size 128x128. Links: [https://stackoverflow.com/a/69787308], [https://github.com/pytorch/pytorch/issues/5057#issuecomment-364208532]