### PR TITLE
Negative sigma bug

### DIFF
--- a/model.py
+++ b/model.py
@@ -14,7 +14,7 @@ class SlotAttention(nn.Module):
         self.scale = dim ** -0.5
 
         self.slots_mu = nn.Parameter(torch.randn(1, 1, dim))
-        self.slots_sigma = nn.Parameter(torch.randn(1, 1, dim))
+        self.slots_sigma = nn.Parameter(torch.rand(1, 1, dim))
 
         self.to_q = nn.Linear(dim, dim)
         self.to_k = nn.Linear(dim, dim)


### PR DESCRIPTION
randn can output negative numbers according to https://pytorch.org/docs/stable/generated/torch.randn.html this causes "RuntimeError: normal expects all elements of std >= 0.0" in model.py  line 40: slots = torch.normal(mu, sigma)

Using rand instead of randn prevents this failure case